### PR TITLE
Remove the ending } to fix variable hightlighting in class defaults

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -20,7 +20,7 @@
         'name': 'storage.type.puppet'
       '2':
         'name': 'entity.name.type.class.puppet'
-    'end': '(?={)'
+    'end': '(?=)'
     'name': 'meta.definition.class.puppet'
     'patterns': [
       {


### PR DESCRIPTION
Fixes an issue where if a default variable is defined in a class the highlighting doesn't stop at the correct brace.
