### PR TITLE
Add end word boundary for if/else/case constructs. Fixes #4

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -93,7 +93,7 @@
     'name': 'meta.definition.resource.puppet'
   }
   {
-    'match': '\\b(case|if|else)(?!::)'
+    'match': '\\b(case|if|else)(?!::)\\b'
     'name': 'keyword.control.puppet'
   }
   {


### PR DESCRIPTION
Wraps the if/else/case language constructs in an ending word boundary as well to prevent it from matching other words like `caserver`.

Before word boundary update:
![old](https://f.cloud.github.com/assets/283234/2453231/9171810c-aedb-11e3-8628-b1f0403ff476.png)

After word boundary update:
![new](https://f.cloud.github.com/assets/283234/2453233/931340ea-aedb-11e3-882a-76ef585c14c9.png)
