### PR TITLE
Fix detection of section name-like strings

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -127,11 +127,11 @@
     'name': 'keyword.control.puppet'
   }
   {
-    'match': '((\\$?)"?[a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*"?):(?=\\s+|$)'
-    'name': 'entity.name.section.puppet'
+    'include': '#strings'
   }
   {
-    'include': '#strings'
+    'match': '((\\$?)"?[a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*"?):(?=\\s+|$)'
+    'name': 'entity.name.section.puppet'
   }
   {
     'include': '#variable'


### PR DESCRIPTION
This fixes detection of (double-quoted) strings containing colons which have been confused with section names. A minimal example is

```
$host = 1.2.3.4
file_line { "add to hosts.allow":
  ensure => present,
  line   => "sshd: ${host}",
  path   => '/etc/hosts.allow',
}
```

where `"sshd:` was previously detected as `entity.name.section.puppet` – resulting in further parsing errors for the rest of the file.