### PR TITLE
An attempt to fix '=>' alignment issues

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -158,7 +158,7 @@
   }
   {
     'match': '=>'
-    'name': 'punctuation.separator.key-value'
+    'name': 'punctuation.separator.key-value.puppet'
   }
 ]
 'repository':

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -156,6 +156,10 @@
     'match': '(?i)\\b(alert|contain|crit|debug|defined|emerg|err|escape|fail|failed|file|generate|gsub|include|info|notice|package|realize|search|tag|tagged|template|warning)\\b'
     'name': 'support.function.puppet'
   }
+  {
+    'match': '=>'
+    'name': 'punctuation.separator.key-value'
+  }
 ]
 'repository':
   'constants':

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -11,3 +11,12 @@ describe "Puppet grammar", ->
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()
     expect(grammar.scopeName).toBe "source.puppet"
+
+  describe "separators", ->
+    it "tokenizes attribute separator", ->
+      {tokens} = grammar.tokenizeLine('ensure => present')
+      expect(tokens[1]).toEqual value: '=>', scopes: ['source.puppet', 'punctuation.separator.key-value.puppet']
+
+    it "tokenizes attribute separator with string values", ->
+      {tokens} = grammar.tokenizeLine('ensure => \"present\"')
+      expect(tokens[1]).toEqual value: '=>', scopes: ['source.puppet', 'punctuation.separator.key-value.puppet']


### PR DESCRIPTION
Bonsoir,

It is an attempt to solve issues related to alignment of '=>' separator.
Honestly, I'm not sure if it is the right way to do it... but it solves problem I encounter in bigbrozer/atom-aligner-puppet#2 and maybe in #15.

I did this because when writing this:

```puppet
class { 'foo':
  ensure => present,
  value => 123,
}
```

I was not able to align the line `value => 123` because the language plugin does not assign a scope (?) to the right side `=> 123`. Doing the proposed change, assign a scope (?) to `123` which allow alignment. The **Dev Tools** helped me to see that.

Hope that's clear enough :-)