### PR TITLE
Recognize node definitions using single quotes

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -18,7 +18,7 @@
     'name': 'comment.block.puppet'
   }
   {
-    'begin': '^\\s*(node|class)\\s+((?:[-_A-Za-z0-9".]+::)*[-_A-Za-z0-9".]+)\\s*'
+    'begin': '^\\s*(node|class)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
     'captures':
       '1':
         'name': 'storage.type.puppet'

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -20,3 +20,12 @@ describe "Puppet grammar", ->
     it "tokenizes attribute separator with string values", ->
       {tokens} = grammar.tokenizeLine('ensure => \"present\"')
       expect(tokens[1]).toEqual value: '=>', scopes: ['source.puppet', 'punctuation.separator.key-value.puppet']
+
+  describe "blocks", ->
+    it "tokenizes single quoted node", ->
+      {tokens} = grammar.tokenizeLine('node \'hostname\' {')
+      expect(tokens[0]).toEqual value: 'node', scopes: ['source.puppet', 'meta.definition.class.puppet', 'storage.type.puppet']
+
+    it "tokenizes double quoted node", ->
+      {tokens} = grammar.tokenizeLine('node "hostname" {')
+      expect(tokens[0]).toEqual value: 'node', scopes: ['source.puppet', 'meta.definition.class.puppet', 'storage.type.puppet']


### PR DESCRIPTION
Hello,
Another pull request to make the grammar recognize node definitions when using single quoted strings for node name.