### PR TITLE
Update puppet grammar

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -146,8 +146,7 @@
     ]
   }
   {
-    'match': '\\b(case|if|else|elsif)(?!::)\\b'
-    'name': 'keyword.control.puppet'
+    'include': '#conditionals'
   }
   {
     'include': '#strings'
@@ -435,5 +434,14 @@
             'name': 'punctuation.definition.variable.puppet'
         'match': '(\\$\\{)(?:[a-zA-Zx7f-xff\\$]|::)(?:[a-zA-Z0-9_x7f-xff\\$]|::)*(\\})'
         'name': 'variable.other.readwrite.global.puppet'
+      }
+    ]
+  'conditionals':
+    'patterns': [
+      {
+        'include': '#comparisons'
+      }
+      {
+        'include': '#cases'
       }
     ]

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -156,7 +156,7 @@
     'name': 'entity.name.section.puppet'
   }
   {
-    'include': '#variable'
+    'include': '#variables'
   }
   {
     'begin': '(?i)\\b(import|include)\\b\\s*'
@@ -206,7 +206,7 @@
         'include': '#escaped_char'
       }
       {
-        'include': '#variable'
+        'include': '#variables'
       }
     ]
   'escaped_char':
@@ -256,7 +256,7 @@
         'include': '#escaped_char'
       }
       {
-        'include': '#variable'
+        'include': '#variables'
       }
       {
         'include': '#nested_braces_interpolated'
@@ -287,7 +287,7 @@
         'include': '#escaped_char'
       }
       {
-        'include': '#variable'
+        'include': '#variables'
       }
       {
         'include': '#nested_brackets_interpolated'
@@ -318,7 +318,7 @@
         'include': '#escaped_char'
       }
       {
-        'include': '#variable'
+        'include': '#variables'
       }
       {
         'include': '#nested_parens_interpolated'
@@ -417,7 +417,7 @@
         'include': '#single-quoted-string'
       }
     ]
-  'variable':
+  'variables':
     'patterns': [
       {
         'captures':

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -45,30 +45,7 @@
         ]
       }
       {
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-        'match': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))'
-        'name': 'meta.function.argument.no-default.puppet'
-      }
-      {
-        'begin': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*'
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-          '3':
-            'name': 'keyword.operator.assignment.puppet'
-        'end': '(?=,|\\))'
-        'name': 'meta.function.argument.default.puppet'
-        'patterns': [
-          {
-            'include': '#parameter-default-types'
-          }
-        ]
+        'include': '#defineparameters'
       }
     ]
   }
@@ -89,30 +66,7 @@
     'name': 'meta.function.puppet'
     'patterns': [
       {
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-        'match': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))'
-        'name': 'meta.function.argument.no-default.puppet'
-      }
-      {
-        'begin': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*'
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-          '3':
-            'name': 'keyword.operator.assignment.puppet'
-        'end': '(?=,|\\))'
-        'name': 'meta.function.argument.default.puppet'
-        'patterns': [
-          {
-            'include': '#parameter-default-types'
-          }
-        ]
+        'include': '#defineparameters'
       }
     ]
   }
@@ -480,3 +434,17 @@
         'name': 'name.metaparameter.puppet'
     'match': '(?:^|\\s)(require|before|notify|subscribe|consumes|exports)\\s*=>'
     'name': 'meta.metaparameter.puppet'
+  'defineparameters':
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.variable.puppet'
+      '2':
+        'name': 'punctuation.definition.variable.puppet'
+    'begin': '(?:^|\\s)(\\$)((?:[a-zA-Zx7f-xff\\$]|::)(?:[a-zA-Z0-9_x7f-xff\\$]|::)*)'
+    'end': ',|\\)'
+    'name': 'meta.assignment.language.puppet'
+    'patterns': [
+      {
+        'include': '#parameter-default-types'
+      }
+    ]

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -21,7 +21,7 @@
     'name': 'comment.block.puppet'
   }
   {
-    'begin': '^\\s*(node|class)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
+    'begin': '^\\s*(node|class|application)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
     'captures':
       '1':
         'name': 'storage.type.puppet'

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -128,6 +128,9 @@
     'name': 'constant.other.bareword.puppet'
   }
   {
+    'include': '#assignments'
+  }
+  {
     'include': '#functions'
   }
 ]

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -440,6 +440,32 @@
         'include': '#cases'
       }
     ]
+  'comparisons':
+    'beginCaptures':
+      '2':
+        'name': 'keyword.control.puppet'
+    'begin': '(^|\\s)\\s*(if|else|unless|elsif)\\s+'
+    'end': '{'
+    'patterns': [
+      {
+        'include': '#parameter-default-types'
+      }
+      {
+        'include': '#comparisonoperators'
+      }
+      {
+        'include': '#negationoperators'
+      }
+    ]
+  'comparisonoperators':
+    'match': '(?:\\s|^)(={2}|!=|>|<|>=|<=|=~|!~|in)(?:\\s|^)'
+    'name': 'keyword.control.puppet'
+  'negationoperators':
+    'captures':
+      '1':
+        'name': 'negation.keyword.control.puppet'
+    'match': '(?:\\s|^)(not|!)(?:\\s|^)'
+    'name': 'meta.keyword.control.puppet'
   'numbers':
     'captures':
       '1':

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -7,6 +7,9 @@
 'name': 'Puppet'
 'patterns': [
   {
+    'include': '#numbers'
+  }
+  {
     'include': '#line_comment'
   }
   {
@@ -445,3 +448,9 @@
         'include': '#cases'
       }
     ]
+  'numbers':
+    'captures':
+      '1':
+        'name': 'number.constant.puppet'
+    'match': '(?:(?:\\D&\\W)|\\s|^|\\[|\\{|,|;|\\()(\\d+([.]\\d+)?)(?!\\w)'
+    'name': 'meta.control.puppet'

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -380,10 +380,6 @@
         'name': 'meta.hash.puppet'
         'patterns': [
           {
-            'match': '\\b\\w+\\s*(?==>)\\s*'
-            'name': 'constant.other.key.puppet'
-          }
-          {
             'include': '#parameter-default-types'
           }
         ]
@@ -431,6 +427,9 @@
         'name': 'variable.other.readwrite.global.puppet'
       }
     ]
+  'constants':
+    'match': '(?:(?:\\D&\\W)|\\s|^|\\[|\\{|,|;|\\()[A-Z]\\w*',
+    'name': 'constant.support.puppet'
   'conditionals':
     'patterns': [
       {

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -170,28 +170,27 @@
     'name': 'meta.include.puppet'
   }
   {
-    'match': '\\b\\w+\\s*(?==>)\\s*'
-    'name': 'constant.other.key.puppet'
-  }
-  {
     'match': '(?<={)\\s*\\w+\\s*(?=})'
     'name': 'constant.other.bareword.puppet'
   }
   {
-    'match': '(?i)\\b(alert|contain|crit|debug|defined|emerg|err|escape|fail|failed|file|generate|gsub|include|info|notice|package|realize|search|tag|tagged|template|warning)\\b'
-    'name': 'support.function.puppet'
-  }
-  {
-    'match': '=>'
-    'name': 'punctuation.separator.key-value.puppet'
+    'include': '#functions'
   }
 ]
 'repository':
-  'constants':
+  'functions':
+    'beginCaptures':
+      '0':
+        'name': 'support.function.puppet'
+    'endCaptures':
+      '0':
+        'name': 'support.function.puppet'
+    'begin': '(?:^|\\s|\\W)(\\w+)\\s*\\('
+    'end': '\\)'
+    'name': 'meta.function.puppet'
     'patterns': [
       {
-        'match': '(?i)\\b(absent|directory|false|file|present|running|stopped|true)\\b'
-        'name': 'constant.language.puppet'
+        'include': '#parameter-default-types'
       }
     ]
   'double-quoted-string':
@@ -345,14 +344,7 @@
         'include': '#array'
       }
       {
-        'begin': '([a-zA-Z_][a-zA-Z0-9_]*)(\\()'
-        'end': '(\\))'
-        'name': 'meta.function.puppet'
-        'patterns': [
-          {
-            'include': '#parameter-default-types'
-          }
-        ]
+        'include': "#functions"
       }
       {
         'include': '#constants'

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -349,6 +349,9 @@
       {
         'include': '#constants'
       }
+      {
+        'include': '#metaparameters'
+      }
     ]
   'array':
       {
@@ -471,3 +474,9 @@
         'name': 'number.constant.puppet'
     'match': '(?:(?:\\D&\\W)|\\s|^|\\[|\\{|,|;|\\()(\\d+([.]\\d+)?)(?!\\w)'
     'name': 'meta.control.puppet'
+  'metaparameters':
+    'captures':
+      '1':
+        'name': 'name.metaparameter.puppet'
+    'match': '(?:^|\\s)(require|before|notify|subscribe|consumes|exports)\\s*=>'
+    'name': 'meta.metaparameter.puppet'

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -27,7 +27,7 @@
         'name': 'storage.type.puppet'
       '2':
         'name': 'entity.name.type.class.puppet'
-    'end': '(?={)'
+    'end': '\\{'
     'name': 'meta.definition.class.puppet'
     'patterns': [
       {
@@ -35,12 +35,12 @@
         'captures':
           '1':
             'name': 'storage.modifier.puppet'
-        'end': '(?={)'
+        'end': '\\{'
         'name': 'meta.definition.class.inherits.puppet'
         'patterns': [
           {
             'match': '\\b((?:[-_A-Za-z0-9".]+::)*[-_A-Za-z0-9".]+)\\b'
-            'name': 'support.type.puppet'
+            'name': 'entity.name.type.class.puppet'
           }
         ]
       }

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -114,13 +114,36 @@
     ]
   }
   {
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'storage.type.puppet'
-      '2':
-        'name': 'entity.name.section.puppet'
-    'match': '^\\s*(\\w+)\\s*{\\s*([\'"].+[\'"]):'
+    'begin': '(\\w+(?::{2}\\w+)*)\\s*{'
     'name': 'meta.definition.resource.puppet'
+    'end': '}'
+    'patterns': [
+      {
+        'include': '#strings'
+      }
+      {
+        'include': '#variables'
+      }
+      {
+        'include': '#metaparameters'
+      }
+      {
+        'beginCaptures':
+          '1':
+            'name': 'name.parameter.resource.puppet'
+        'begin': '(?:^|\\W)(\\w+)\\s*=>'
+        'name': 'meta.parameter.resource.puppet'
+        'end': '(,|\\n|;)'
+        'patterns': [
+          {
+            'include': '#parameter-default-types'
+          }
+        ]
+      }
+    ]
   }
   {
     'match': '\\b(case|if|else|elsif)(?!::)\\b'


### PR DESCRIPTION
This pull request updates the puppet grammar to improve matching of classes, comparisons, functions, numbers, and resource parameters.  In addition, it improves the parameter matching for class, defined type, and application definitions.

This turned out to be a large PR, so I'm happy to work through it as works best for the maintainers.