### PR TITLE
Update puppet grammar

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -22,12 +22,15 @@
   }
   {
     'begin': '^\\s*(node|class|application)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'storage.type.puppet'
       '2':
         'name': 'entity.name.type.class.puppet'
-    'end': '\\{'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.class.begin.puppet'
+    'end': '{'
     'name': 'meta.definition.class.puppet'
     'patterns': [
       {
@@ -35,7 +38,7 @@
         'captures':
           '1':
             'name': 'storage.modifier.puppet'
-        'end': '\\{'
+        'end': '{'
         'name': 'meta.definition.class.inherits.puppet'
         'patterns': [
           {

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -7,6 +7,9 @@
 'name': 'Puppet'
 'patterns': [
   {
+    'include': '#numbers'
+  }
+  {
     'include': '#line_comment'
   }
   {

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -21,7 +21,7 @@
     'name': 'comment.block.puppet'
   }
   {
-    'begin': '^\\s*(node|class|application)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
+    'begin': '^\\s*(node|define|class|application)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
     'beginCaptures':
       '1':
         'name': 'storage.type.puppet'
@@ -47,27 +47,6 @@
           }
         ]
       }
-      {
-        'include': '#defineparameters'
-      }
-    ]
-  }
-  {
-    'begin': '^\\s*(define)\\s+([a-zA-Z0-9_:]+)\\s*(\\()'
-    'beginCaptures':
-      '1':
-        'name': 'storage.type.function.puppet'
-      '2':
-        'name': 'entity.name.function.puppet'
-      '3':
-        'name': 'punctuation.definition.parameters.begin.puppet'
-    'contentName': 'meta.function.arguments.puppet'
-    'end': '\\)'
-    'endCaptures':
-      '1':
-        'name': 'punctuation.definition.parameters.end.puppet'
-    'name': 'meta.function.puppet'
-    'patterns': [
       {
         'include': '#defineparameters'
       }

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -156,7 +156,7 @@
     'name': 'entity.name.section.puppet'
   }
   {
-    'include': '#variable'
+    'include': '#variables'
   }
   {
     'begin': '(?i)\\b(import|include)\\b\\s*'
@@ -206,7 +206,7 @@
         'include': '#escaped_char'
       }
       {
-        'include': '#variable'
+        'include': '#variables'
       }
     ]
   'escaped_char':
@@ -256,7 +256,7 @@
         'include': '#escaped_char'
       }
       {
-        'include': '#variable'
+        'include': '#variables'
       }
       {
         'include': '#nested_braces_interpolated'
@@ -287,7 +287,7 @@
         'include': '#escaped_char'
       }
       {
-        'include': '#variable'
+        'include': '#variables'
       }
       {
         'include': '#nested_brackets_interpolated'
@@ -318,7 +318,7 @@
         'include': '#escaped_char'
       }
       {
-        'include': '#variable'
+        'include': '#variables'
       }
       {
         'include': '#nested_parens_interpolated'
@@ -417,7 +417,7 @@
         'include': '#single-quoted-string'
       }
     ]
-  'variable':
+  'variables':
     'patterns': [
       {
         'captures':

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -7,13 +7,13 @@
 'name': 'Puppet'
 'patterns': [
   {
-    'include': '#numbers'
-  }
-  {
     'include': '#line_comment'
   }
   {
     'include': '#constants'
+  }
+  {
+    'include': '#hash'
   }
   {
     'begin': '^\\s*/\\*'

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -21,7 +21,7 @@
     'name': 'comment.block.puppet'
   }
   {
-    'begin': '^\\s*(node|class)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
+    'begin': '^\\s*(node|class|application)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
     'captures':
       '1':
         'name': 'storage.type.puppet'

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -128,6 +128,9 @@
     'name': 'constant.other.bareword.puppet'
   }
   {
+    'include': '#assignments'
+  }
+  {
     'include': '#functions'
   }
 ]

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -45,30 +45,7 @@
         ]
       }
       {
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-        'match': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))'
-        'name': 'meta.function.argument.no-default.puppet'
-      }
-      {
-        'begin': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*'
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-          '3':
-            'name': 'keyword.operator.assignment.puppet'
-        'end': '(?=,|\\))'
-        'name': 'meta.function.argument.default.puppet'
-        'patterns': [
-          {
-            'include': '#parameter-default-types'
-          }
-        ]
+        'include': '#defineparameters'
       }
     ]
   }
@@ -89,30 +66,7 @@
     'name': 'meta.function.puppet'
     'patterns': [
       {
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-        'match': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))'
-        'name': 'meta.function.argument.no-default.puppet'
-      }
-      {
-        'begin': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*'
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-          '3':
-            'name': 'keyword.operator.assignment.puppet'
-        'end': '(?=,|\\))'
-        'name': 'meta.function.argument.default.puppet'
-        'patterns': [
-          {
-            'include': '#parameter-default-types'
-          }
-        ]
+        'include': '#defineparameters'
       }
     ]
   }
@@ -471,3 +425,18 @@
         'name': 'number.constant.puppet'
     'match': '(?:(?:\\D&\\W)|\\s|^|\\[|\\{|,|;|\\()(\\d+([.]\\d+)?)(?!\\w)'
     'name': 'meta.control.puppet'
+  'defineparameters':
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.classparameter.begin.puppet'
+    'begin': '\\('
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.classparameter.end.puppet'
+    'end': '\\)'
+    'name': 'meta.classparameter.language.puppet'
+    'patterns': [
+      {
+        'include': '#parameter-default-types'
+      }
+    ]

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -380,10 +380,6 @@
         'name': 'meta.hash.puppet'
         'patterns': [
           {
-            'match': '\\b\\w+\\s*(?==>)\\s*'
-            'name': 'constant.other.key.puppet'
-          }
-          {
             'include': '#parameter-default-types'
           }
         ]
@@ -431,6 +427,9 @@
         'name': 'variable.other.readwrite.global.puppet'
       }
     ]
+  'constants':
+    'match': '(?:(?:\\D&\\W)|\\s|^|\\[|\\{|,|;|\\()[A-Z]\\w*',
+    'name': 'constant.support.puppet'
   'conditionals':
     'patterns': [
       {

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -82,7 +82,7 @@
         'captures':
           '1':
             'name': 'name.title.puppet'
-        'match': '\\s*(.*):\\s*|\\n'
+        'match': '\\s*(.*):'
         'name': 'meta.title.puppet'
       }
       {
@@ -98,9 +98,11 @@
         'beginCaptures':
           '1':
             'name': 'name.parameter.resource.puppet'
-        'begin': '(?:^|\\W)(\\w+)\\s*=>'
+          '2':
+            'name': 'punctuation.separator.key-value.puppet'
+        'begin': '(\\w+)\\s*(=>)'
         'name': 'meta.parameter.resource.puppet'
-        'end': '(,|\\n|;)'
+        'end': ',|\\n|;'
         'patterns': [
           {
             'include': '#parameter-default-types'
@@ -333,16 +335,23 @@
       }
   'hash':
       {
-        'begin': '\\{'
+        'begin': '{'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.hash.begin.puppet'
-        'end': '\\}'
+        'end': '}'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.hash.end.puppet'
         'name': 'meta.hash.puppet'
         'patterns': [
+          {
+            'captures':
+              '0':
+                'name': 'punctuation.separator.key-value.puppet'
+            'match': '=>'
+            'name': 'meta.punctuation.hash.puppet'
+          }
           {
             'include': '#parameter-default-types'
           }

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -170,28 +170,27 @@
     'name': 'meta.include.puppet'
   }
   {
-    'match': '\\b\\w+\\s*(?==>)\\s*'
-    'name': 'constant.other.key.puppet'
-  }
-  {
     'match': '(?<={)\\s*\\w+\\s*(?=})'
     'name': 'constant.other.bareword.puppet'
   }
   {
-    'match': '(?i)\\b(alert|contain|crit|debug|defined|emerg|err|escape|fail|failed|file|generate|gsub|include|info|notice|package|realize|search|tag|tagged|template|warning)\\b'
-    'name': 'support.function.puppet'
-  }
-  {
-    'match': '=>'
-    'name': 'punctuation.separator.key-value.puppet'
+    'include': '#functions'
   }
 ]
 'repository':
-  'constants':
+  'functions':
+    'beginCaptures':
+      '0':
+        'name': 'support.function.puppet'
+    'endCaptures':
+      '0':
+        'name': 'support.function.puppet'
+    'begin': '(?:^|\\s|\\W)(\\w+)\\s*\\('
+    'end': '\\)'
+    'name': 'meta.function.puppet'
     'patterns': [
       {
-        'match': '(?i)\\b(absent|directory|false|file|present|running|stopped|true)\\b'
-        'name': 'constant.language.puppet'
+        'include': '#parameter-default-types'
       }
     ]
   'double-quoted-string':
@@ -345,14 +344,7 @@
         'include': '#array'
       }
       {
-        'begin': '([a-zA-Z_][a-zA-Z0-9_]*)(\\()'
-        'end': '(\\))'
-        'name': 'meta.function.puppet'
-        'patterns': [
-          {
-            'include': '#parameter-default-types'
-          }
-        ]
+        'include': "#functions"
       }
       {
         'include': '#constants'

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -74,10 +74,17 @@
     'beginCaptures':
       '1':
         'name': 'storage.type.puppet'
-    'begin': '(\\w+(?::{2}\\w+)*)\\s*{'
+    'begin': '((?:[-_A-Za-z0-9".]+::)*[-_A-Za-z0-9".]+)\\s*{'
     'name': 'meta.definition.resource.puppet'
     'end': '}'
     'patterns': [
+      {
+        'captures':
+          '1':
+            'name': 'name.title.puppet'
+        'match': '\\s*(.*):\\s*|\\n'
+        'name': 'meta.title.puppet'
+      }
       {
         'include': '#strings'
       }

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -146,8 +146,7 @@
     ]
   }
   {
-    'match': '\\b(case|if|else|elsif)(?!::)\\b'
-    'name': 'keyword.control.puppet'
+    'include': '#conditionals'
   }
   {
     'include': '#strings'
@@ -437,3 +436,44 @@
         'name': 'variable.other.readwrite.global.puppet'
       }
     ]
+  'conditionals':
+    'patterns': [
+      {
+        'include': '#comparisons'
+      }
+      {
+        'include': '#cases'
+      }
+    ]
+  'comparisons':
+    'beginCaptures':
+      '2':
+        'name': 'keyword.control.puppet'
+    'begin': '(^|\\s)\\s*(if|else|unless|elsif)\\s+'
+    'end': '{'
+    'patterns': [
+      {
+        'include': '#parameter-default-types'
+      }
+      {
+        'include': '#comparisonoperators'
+      }
+      {
+        'include': '#negationoperators'
+      }
+    ]
+  'comparisonoperators':
+    'match': '(?:\\s|^)(={2}|!=|>|<|>=|<=|=~|!~|in)(?:\\s|^)'
+    'name': 'keyword.control.puppet'
+  'negationoperators':
+    'captures':
+      '1':
+        'name': 'negation.keyword.control.puppet'
+    'match': '(?:\\s|^)(not|!)(?:\\s|^)'
+    'name': 'meta.keyword.control.puppet'
+  'numbers':
+    'captures':
+      '1':
+        'name': 'number.constant.puppet'
+    'match': '(?:(?:\\D&\\W)|\\s|^|\\[|\\{|,|;|\\()(\\d+([.]\\d+)?)(?!\\w)'
+    'name': 'meta.control.puppet'

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -27,7 +27,7 @@
         'name': 'storage.type.puppet'
       '2':
         'name': 'entity.name.type.class.puppet'
-    'end': '(?={)'
+    'end': '\\{'
     'name': 'meta.definition.class.puppet'
     'patterns': [
       {
@@ -35,12 +35,12 @@
         'captures':
           '1':
             'name': 'storage.modifier.puppet'
-        'end': '(?={)'
+        'end': '\\{'
         'name': 'meta.definition.class.inherits.puppet'
         'patterns': [
           {
             'match': '\\b((?:[-_A-Za-z0-9".]+::)*[-_A-Za-z0-9".]+)\\b'
-            'name': 'support.type.puppet'
+            'name': 'entity.name.type.class.puppet'
           }
         ]
       }

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -114,13 +114,36 @@
     ]
   }
   {
-    'captures':
+    'beginCaptures':
       '1':
         'name': 'storage.type.puppet'
-      '2':
-        'name': 'entity.name.section.puppet'
-    'match': '^\\s*(\\w+)\\s*{\\s*([\'"].+[\'"]):'
+    'begin': '(\\w+(?::{2}\\w+)*)\\s*{'
     'name': 'meta.definition.resource.puppet'
+    'end': '}'
+    'patterns': [
+      {
+        'include': '#strings'
+      }
+      {
+        'include': '#variables'
+      }
+      {
+        'include': '#metaparameters'
+      }
+      {
+        'beginCaptures':
+          '1':
+            'name': 'name.parameter.resource.puppet'
+        'begin': '(?:^|\\W)(\\w+)\\s*=>'
+        'name': 'meta.parameter.resource.puppet'
+        'end': '(,|\\n|;)'
+        'patterns': [
+          {
+            'include': '#parameter-default-types'
+          }
+        ]
+      }
+    ]
   }
   {
     'match': '\\b(case|if|else|elsif)(?!::)\\b'

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -63,8 +63,8 @@
       {
         'captures':
           '1':
-            'name': 'name.title.puppet'
-        'match': '\\s*(.*):'
+            'name': 'punctuation.classtitle.puppet'
+        'match': '(:)'
         'name': 'meta.title.puppet'
       }
       {
@@ -383,8 +383,23 @@
       }
     ]
   'constants':
-    'match': '(?:(?:\\D&\\W)|\\s|^|\\[|\\{|,|;|\\()[A-Z]\\w*',
-    'name': 'constant.support.puppet'
+    'beginCaptures':
+      '0':
+        'name': 'constant.support.puppet'
+    'begin': '((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\['
+    'endCaptures':
+      '0':
+        'name': 'constant.support.puppet'
+    'end': '\\]'
+    'patterns': [
+      {
+        'include': '#strings'
+      }
+      {
+        'include': '#variables'
+      }
+    ]
+
   'conditionals':
     'patterns': [
       {

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -49,6 +49,18 @@ describe "Puppet grammar", ->
       expect(tokens[23]).toEqual value: 'inherits', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.definition.class.inherits.puppet', 'storage.modifier.puppet']
       expect(tokens[25]).toEqual value: 'another::class', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.definition.class.inherits.puppet', 'entity.name.type.class.puppet']
 
+  describe "applications", ->
+    it 'should tokenize an application without parameters', ->
+      {tokens} = grammar.tokenizeLine("application appname {  }")
+      expect(tokens[0]).toEqual value: 'application', scopes: ['source.puppet', 'meta.definition.class.puppet', 'storage.type.puppet']
+      expect(tokens[2]).toEqual value: 'appname', scopes: ['source.puppet', 'meta.definition.class.puppet', 'entity.name.type.class.puppet']
+      expect(tokens[4]).toEqual value: '{', scopes: [ 'source.puppet', 'meta.definition.class.puppet', 'punctuation.definition.class.begin.puppet' ]
+
+    it 'should tokenize an application with parameters', ->
+      {tokens} = grammar.tokenizeLine("application appname ( $parameter1, $parameter2 = 'value', $parameter3 = $classname::params) {  }")
+      expect(tokens[4]).toEqual value: '(', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.classparameter.language.puppet', 'punctuation.definition.classparameter.begin.puppet']
+      expect(tokens[21]).toEqual value: ')', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.classparameter.language.puppet', 'punctuation.definition.classparameter.end.puppet']
+
   describe "blocks", ->
     it "tokenizes single quoted node", ->
       {tokens} = grammar.tokenizeLine("node 'hostname' {")

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -32,6 +32,23 @@ describe "Puppet grammar", ->
       expect(tokens[8]).toEqual value: '=>', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'meta.parameter.resource.puppet', 'punctuation.separator.key-value.puppet']
 
 
+  describe "classes", ->
+    it 'should tokenize a class without parameters', ->
+      {tokens} = grammar.tokenizeLine("class classname {  }")
+      expect(tokens[0]).toEqual value: 'class', scopes: ['source.puppet', 'meta.definition.class.puppet', 'storage.type.puppet']
+      expect(tokens[2]).toEqual value: 'classname', scopes: ['source.puppet', 'meta.definition.class.puppet', 'entity.name.type.class.puppet']
+      expect(tokens[4]).toEqual value: '{', scopes: [ 'source.puppet', 'meta.definition.class.puppet', 'punctuation.definition.class.begin.puppet' ]
+
+    it 'should tokenize a class with parameters', ->
+      {tokens} = grammar.tokenizeLine("class classname ( $parameter1, $parameter2 = 'value', $parameter3 = $classname::params) {  }")
+      expect(tokens[4]).toEqual value: '(', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.classparameter.language.puppet', 'punctuation.definition.classparameter.begin.puppet']
+      expect(tokens[21]).toEqual value: ')', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.classparameter.language.puppet', 'punctuation.definition.classparameter.end.puppet']
+
+    it 'should tokenize a class with ineritence', ->
+      {tokens} = grammar.tokenizeLine("class classname ( $parameter1, $parameter2 = 'value', $parameter3 = $classname::params) inherits another::class {  }")
+      expect(tokens[23]).toEqual value: 'inherits', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.definition.class.inherits.puppet', 'storage.modifier.puppet']
+      expect(tokens[25]).toEqual value: 'another::class', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.definition.class.inherits.puppet', 'entity.name.type.class.puppet']
+
   describe "blocks", ->
     it "tokenizes single quoted node", ->
       {tokens} = grammar.tokenizeLine("node 'hostname' {")

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -61,6 +61,18 @@ describe "Puppet grammar", ->
       expect(tokens[4]).toEqual value: '(', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.classparameter.language.puppet', 'punctuation.definition.classparameter.begin.puppet']
       expect(tokens[21]).toEqual value: ')', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.classparameter.language.puppet', 'punctuation.definition.classparameter.end.puppet']
 
+  describe "defined types", ->
+    it 'should tokenize a defined type without parameters', ->
+      {tokens} = grammar.tokenizeLine("define typename {  }")
+      expect(tokens[0]).toEqual value: 'define', scopes: ['source.puppet', 'meta.definition.class.puppet', 'storage.type.puppet']
+      expect(tokens[2]).toEqual value: 'typename', scopes: ['source.puppet', 'meta.definition.class.puppet', 'entity.name.type.class.puppet']
+      expect(tokens[4]).toEqual value: '{', scopes: [ 'source.puppet', 'meta.definition.class.puppet', 'punctuation.definition.class.begin.puppet' ]
+
+    it 'should tokenize a defined type with parameters', ->
+      {tokens} = grammar.tokenizeLine("define typename ( $parameter1, $parameter2 = 'value', $parameter3 = $classname::params) {  }")
+      expect(tokens[4]).toEqual value: '(', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.classparameter.language.puppet', 'punctuation.definition.classparameter.begin.puppet']
+      expect(tokens[21]).toEqual value: ')', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.classparameter.language.puppet', 'punctuation.definition.classparameter.end.puppet']
+
   describe "blocks", ->
     it "tokenizes single quoted node", ->
       {tokens} = grammar.tokenizeLine("node 'hostname' {")

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -12,14 +12,25 @@ describe "Puppet grammar", ->
     expect(grammar).toBeTruthy()
     expect(grammar.scopeName).toBe "source.puppet"
 
-  describe "separators", ->
-    it "tokenizes attribute separator", ->
-      {tokens} = grammar.tokenizeLine('ensure => present')
-      expect(tokens[1]).toEqual value: '=>', scopes: ['source.puppet', 'punctuation.separator.key-value.puppet']
+  describe "resources", ->
+    manifest = "type { title: parameter1 => 'stringvalue', inlineparameter => Resource['reference']; }"
 
-    it "tokenizes attribute separator with string values", ->
-      {tokens} = grammar.tokenizeLine('ensure => "present"')
-      expect(tokens[1]).toEqual value: '=>', scopes: ['source.puppet', 'punctuation.separator.key-value.puppet']
+    it 'tokenizes resource types', ->
+      {tokens} = grammar.tokenizeLine(manifest)
+      expect(tokens[0]).toEqual value: 'type', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'storage.type.puppet']
+
+    it 'tokenizes resource titles', ->
+      {tokens} = grammar.tokenizeLine(manifest)
+      expect(tokens[3]).toEqual value: 'title', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'meta.title.puppet', 'name.title.puppet']
+
+    it 'tokenizes resource parameter', ->
+      {tokens} = grammar.tokenizeLine(manifest)
+      expect(tokens[6]).toEqual value: 'parameter1', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'meta.parameter.resource.puppet', 'name.parameter.resource.puppet']
+
+    it 'tokenizes resource parameter separators', ->
+      {tokens} = grammar.tokenizeLine(manifest)
+      expect(tokens[8]).toEqual value: '=>', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'meta.parameter.resource.puppet', 'punctuation.separator.key-value.puppet']
+
 
   describe "blocks", ->
     it "tokenizes single quoted node", ->

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -73,7 +73,13 @@ describe "Puppet grammar", ->
       expect(tokens[4]).toEqual value: '(', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.classparameter.language.puppet', 'punctuation.definition.classparameter.begin.puppet']
       expect(tokens[21]).toEqual value: ')', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.classparameter.language.puppet', 'punctuation.definition.classparameter.end.puppet']
 
-  describe "blocks", ->
+  describe "constants", ->
+    it 'should tokenize a resource reference', ->
+      {tokens} = grammar.tokenizeLine("Resource::Reference[title]")
+      expect(tokens[0]).toEqual value: "Resource::Reference[", scopes: ['source.puppet', 'constant.support.puppet']
+      expect(tokens[2]).toEqual value: "]", scopes: ['source.puppet', 'constant.support.puppet']
+
+  describe "nodes", ->
     it "tokenizes single quoted node", ->
       {tokens} = grammar.tokenizeLine("node 'hostname' {")
       expect(tokens[0]).toEqual value: 'node', scopes: ['source.puppet', 'meta.definition.class.puppet', 'storage.type.puppet']

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -19,17 +19,17 @@ describe "Puppet grammar", ->
       {tokens} = grammar.tokenizeLine(manifest)
       expect(tokens[0]).toEqual value: 'type', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'storage.type.puppet']
 
-    it 'tokenizes resource titles', ->
+    it 'tokenizes resource title punctuation', ->
       {tokens} = grammar.tokenizeLine(manifest)
-      expect(tokens[3]).toEqual value: 'title', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'meta.title.puppet', 'name.title.puppet']
+      expect(tokens[3]).toEqual value: ':', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'meta.title.puppet', 'punctuation.classtitle.puppet']
 
     it 'tokenizes resource parameter', ->
       {tokens} = grammar.tokenizeLine(manifest)
-      expect(tokens[6]).toEqual value: 'parameter1', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'meta.parameter.resource.puppet', 'name.parameter.resource.puppet']
+      expect(tokens[5]).toEqual value: 'parameter1', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'meta.parameter.resource.puppet', 'name.parameter.resource.puppet']
 
     it 'tokenizes resource parameter separators', ->
       {tokens} = grammar.tokenizeLine(manifest)
-      expect(tokens[8]).toEqual value: '=>', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'meta.parameter.resource.puppet', 'punctuation.separator.key-value.puppet']
+      expect(tokens[7]).toEqual value: '=>', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'meta.parameter.resource.puppet', 'punctuation.separator.key-value.puppet']
 
 
   describe "classes", ->

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -87,3 +87,9 @@ describe "Puppet grammar", ->
     it "tokenizes double quoted node", ->
       {tokens} = grammar.tokenizeLine('node "hostname" {')
       expect(tokens[0]).toEqual value: 'node', scopes: ['source.puppet', 'meta.definition.class.puppet', 'storage.type.puppet']
+
+  describe "functions", ->
+    it 'should tokenize a function with no space between name and (', ->
+      {tokens} = grammar.tokenizeLine('function()')
+      expect(tokens[0]).toEqual value: 'function(', scopes: [ 'source.puppet', 'meta.function.puppet', 'support.function.puppet' ]
+      expect(tokens[1]).toEqual value: ')', scopes: [ 'source.puppet', 'meta.function.puppet', 'support.function.puppet']


### PR DESCRIPTION
This pull request updates the puppet grammar to improve matching of classes, comparisons, functions, numbers, and resource parameters. In addition, it improves the parameter matching for class, defined type, and application definitions.  This still needs lots more test coverage and it doesn't yet cover the additional syntaxes added in Puppet 4.

This turned out to be a large PR, so I'm happy to work through it as works best for the maintainers.  