### PR TITLE
Adds `require` as an `include` highlight

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -146,7 +146,7 @@
     'include': '#variable'
   }
   {
-    'begin': '(?i)\\b(import|include|contain)\\b\\s*'
+    'begin': '\\b(import|include|contain|require)\\s+(?!.*=>)'
     'beginCaptures':
       '1':
         'name': 'keyword.control.import.include.puppet'

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -47,3 +47,11 @@ describe "Puppet grammar", ->
       {tokens} = grammar.tokenizeLine("package {$foo:}")
       expect(tokens[0]).toEqual value: 'package', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'storage.type.puppet']
       expect(tokens[2]).toEqual value: '$foo', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'entity.name.section.puppet']
+
+    it "tokenizes require classname as an include", ->
+      {tokens} = grammar.tokenizeLine("require ::foo")
+      expect(tokens[0]).toEqual value: 'require', scopes: ['source.puppet', 'meta.include.puppet', 'keyword.control.import.include.puppet']
+
+    it "tokenizes require => variable as a parameter", ->
+      {tokens} = grammar.tokenizeLine("require => Class['foo']")
+      expect(tokens[0]).toEqual value: 'require ', scopes: ['source.puppet', 'constant.other.key.puppet']


### PR DESCRIPTION
See https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html#syntax-the-require-function

~~The only problem I have right now is figuring out making it only apply the highlight when doing `require ::foo` not `require =>` the metaparameter.~~

~~I've added a failing test, I still need to figure out the regex to capture it properly:~~

<img width="350" alt="screenshot 2016-03-11 12 53 23" src="https://cloud.githubusercontent.com/assets/1064715/13702680/427d76c2-e788-11e5-9d39-e9b229afc51b.png">

Now fixed! :smile: 
<img width="266" alt="screenshot 2016-03-12 21 10 15" src="https://cloud.githubusercontent.com/assets/1064715/13725361/d5bfa05e-e896-11e5-9142-2b1c84e752a6.png">
