### PR TITLE
Fixes resources with variable name

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -123,6 +123,15 @@
     'name': 'meta.definition.resource.puppet'
   }
   {
+    'match': '^\\s*(\\w+)\\s*{\\s*(\\$[a-zA-Z_]+)\\s*:'
+    'captures':
+      '1':
+        'name': 'storage.type.puppet'
+      '2':
+        'name': 'entity.name.section.puppet'
+    'name': 'meta.definition.resource.puppet'
+  }
+  {
     'match': '\\b(case|if|else|elsif)(?!::)\\b'
     'name': 'keyword.control.puppet'
   }

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -37,3 +37,13 @@ describe "Puppet grammar", ->
     it "tokenizes contain as an include function", ->
       {tokens} = grammar.tokenizeLine('include foo')
       expect(tokens[0]).toEqual value: 'include', scopes: ['source.puppet', 'meta.include.puppet', 'keyword.control.import.include.puppet']
+
+    it "tokenizes resource type and string title", ->
+      {tokens} = grammar.tokenizeLine("package {'foo':}")
+      expect(tokens[0]).toEqual value: 'package', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'storage.type.puppet']
+      expect(tokens[2]).toEqual value: "'foo'", scopes: ['source.puppet', 'meta.definition.resource.puppet', 'entity.name.section.puppet']
+
+    it "tokenizes resource type and variable title", ->
+      {tokens} = grammar.tokenizeLine("package {$foo:}")
+      expect(tokens[0]).toEqual value: 'package', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'storage.type.puppet']
+      expect(tokens[2]).toEqual value: '$foo', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'entity.name.section.puppet']


### PR DESCRIPTION
Lifted heavily from https://github.com/russCloak/SublimePuppet/pull/20

Before:
<img width="269" alt="screenshot 2016-03-11 15 38 11" src="https://cloud.githubusercontent.com/assets/1064715/13706971/63cdbc76-e79f-11e5-8d30-e73682f99b35.png">

After:
<img width="264" alt="screenshot 2016-03-11 15 42 11" src="https://cloud.githubusercontent.com/assets/1064715/13707076/d7a39f1c-e79f-11e5-85de-acfc4531608d.png">
