### PR TITLE
Fix grammar for file type

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -162,7 +162,7 @@
     'name': 'constant.other.bareword.puppet'
   }
   {
-    'match': '(?i)\\b(alert|crit|debug|defined|emerg|err|escape|fail|failed|file|generate|gsub|info|notice|package|realize|search|tag|tagged|template|warning)\\b'
+    'match': '\\b(alert|crit|debug|defined|emerg|err|escape|fail|failed|file|generate|gsub|info|notice|package|realize|search|tag|tagged|template|warning)\\b(?!.*{)'
     'name': 'support.function.puppet'
   }
   {
@@ -174,7 +174,7 @@
   'constants':
     'patterns': [
       {
-        'match': '(?i)\\b(absent|directory|false|file|present|running|stopped|true)\\b'
+        'match': '\\b(absent|directory|false|file|present|running|stopped|true)\\b(?!.*{)'
         'name': 'constant.language.puppet'
       }
     ]

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -72,3 +72,10 @@ describe "Puppet grammar", ->
       {tokens} = grammar.tokenizeLine('$::foo')
       expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
       expect(tokens[1]).toEqual value: '::foo', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+    it "tokenizes resource types correctly", ->
+      {tokens} = grammar.tokenizeLine("file {'/var/tmp':}")
+      expect(tokens[0]).toEqual value: 'file', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'storage.type.puppet']
+
+      {tokens} = grammar.tokenizeLine("package {'foo':}")
+      expect(tokens[0]).toEqual value: 'package', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'storage.type.puppet']


### PR DESCRIPTION
Since file was defined as a constant for the `ensure => file` pattern, it would incorrectly highlight the file resource.