### PR TITLE
Add epp file type

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -1,6 +1,7 @@
 'scopeName': 'source.puppet'
 'fileTypes': [
-  'pp'
+  'pp',
+  'epp'
 ]
 'foldingStartMarker': '(^\\s*/\\*|(\\{|\\[|\\()\\s*$)'
 'foldingStopMarker': '(\\*/|^\\s*(\\}|\\]|\\)))'

--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -1,6 +1,6 @@
 'scopeName': 'source.puppet'
 'fileTypes': [
-  'pp',
+  'pp'
   'epp'
 ]
 'foldingStartMarker': '(^\\s*/\\*|(\\{|\\[|\\()\\s*$)'


### PR DESCRIPTION
Add epp file type for Embedded Puppet templating language, so that atom show
syntax hightlighting for it.

demo: 
![first open source contribution 2](https://cloud.githubusercontent.com/assets/10424206/14294230/7342926e-fb89-11e5-91ce-77cfc485df2c.PNG)
