### PR TITLE
Parameter typing and comments

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -43,14 +43,31 @@
         ]
       }
       {
+        'include' : '#line_comment'
+      }
+      # `$param,`
+      {
         'captures':
           '1':
             'name': 'variable.other.puppet'
           '2':
             'name': 'punctuation.definition.variable.puppet'
         'match': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))'
-        'name': 'meta.function.argument.no-default.puppet'
+        'name': 'meta.function.argument.no-default.untyped.puppet'
       }
+      # Type `$param,`
+      {
+        'captures':
+          '1':
+            'name': 'storage.type.puppet'
+          '2':
+            'name': 'variable.other.puppet'
+          '3':
+            'name': 'punctuation.definition.variable.puppet'
+        'match': '((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))'
+        'name': 'meta.function.argument.no-default.typed.puppet'
+      }
+      # `$param = ...,`
       {
         'begin': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*'
         'captures':
@@ -61,7 +78,22 @@
           '3':
             'name': 'keyword.operator.assignment.puppet'
         'end': '(?=,|\\))'
-        'name': 'meta.function.argument.default.puppet'
+        'name': 'meta.function.argument.default.untyped.puppet'
+      }
+      # Type `$param = ...,`
+      {
+        'begin': '((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*'
+        'captures':
+          '1':
+            'name': 'storage.type.puppet'
+          '2':
+            'name': 'variable.other.puppet'
+          '3':
+            'name': 'punctuation.definition.variable.puppet'
+          '4':
+            'name': 'keyword.operator.assignment.puppet'
+        'end': '(?=,|\\))'
+        'name': 'meta.function.argument.default.typed.puppet'
         'patterns': [
           {
             'include': '#parameter-default-types'

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -30,6 +30,16 @@ describe "Puppet grammar", ->
       {tokens} = grammar.tokenizeLine('node "hostname" {')
       expect(tokens[0]).toEqual value: 'node', scopes: ['source.puppet', 'meta.definition.class.puppet', 'storage.type.puppet']
 
+    it "tokenizes non-default class parameters", ->
+      {tokens} = grammar.tokenizeLine('class "classname" ($myvar) {')
+      expect(tokens[5]).toEqual value: '$', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.function.argument.no-default.untyped.puppet', 'variable.other.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[6]).toEqual value: 'myvar', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.function.argument.no-default.untyped.puppet', 'variable.other.puppet']
+
+    it "tokenizes default class parameters", ->
+      {tokens} = grammar.tokenizeLine('class "classname" ($myvar = "myval") {')
+      expect(tokens[5]).toEqual value: '$', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.function.argument.default.untyped.puppet', 'variable.other.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[6]).toEqual value: 'myvar', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.function.argument.default.untyped.puppet', 'variable.other.puppet']
+
     it "tokenizes non-default class parameter types", ->
       {tokens} = grammar.tokenizeLine('class "classname" (String $myvar) {')
       expect(tokens[5]).toEqual value: 'String', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.function.argument.no-default.typed.puppet', 'storage.type.puppet']

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -30,6 +30,14 @@ describe "Puppet grammar", ->
       {tokens} = grammar.tokenizeLine('node "hostname" {')
       expect(tokens[0]).toEqual value: 'node', scopes: ['source.puppet', 'meta.definition.class.puppet', 'storage.type.puppet']
 
+    it "tokenizes non-default class parameter types", ->
+      {tokens} = grammar.tokenizeLine('class "classname" (String $myvar) {')
+      expect(tokens[5]).toEqual value: 'String', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.function.argument.no-default.typed.puppet', 'storage.type.puppet']
+
+    it "tokenizes default class parameter types", ->
+      {tokens} = grammar.tokenizeLine('class "classname" (String $myvar = "myval") {')
+      expect(tokens[5]).toEqual value: 'String', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.function.argument.default.typed.puppet', 'storage.type.puppet']
+
     it "tokenizes include as an include function", ->
       {tokens} = grammar.tokenizeLine("contain foo")
       expect(tokens[0]).toEqual value: 'contain', scopes: ['source.puppet', 'meta.include.puppet', 'keyword.control.import.include.puppet']


### PR DESCRIPTION
Fixes #36 
Fixes #37

I don't think this fix is totally correct. Specifically, I call the type definition a `string.quoted.single.puppet` because it gives a different colour, but I don't really understand the significance of doing so, or how I'd get a dedicated name.

I think it might be nice for the type to be uncoloured (like the equals sign), but not sure.

Before:
<img width="375" alt="screen shot 2016-08-04 at 12 27 05 pm" src="https://cloud.githubusercontent.com/assets/379509/17388311/cd5657b8-5a3e-11e6-8ee8-ed1388488d8c.png">

After:
<img width="358" alt="screen shot 2016-08-04 at 12 26 32 pm" src="https://cloud.githubusercontent.com/assets/379509/17388299/b7018140-5a3e-11e6-886e-197a8ad4ea54.png">
