### PR TITLE
Don't treat epp files as Puppet code

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -1,7 +1,6 @@
 'scopeName': 'source.puppet'
 'fileTypes': [
   'pp'
-  'epp'
 ]
 'foldingStartMarker': '(^\\s*/\\*|(\\{|\\[|\\()\\s*$)'
 'foldingStopMarker': '(\\*/|^\\s*(\\}|\\]|\\)))'


### PR DESCRIPTION
The ERB grammar is fine to be used for EPP, but I'm not sure how to create an 'EPP' grammar that simply inherits from ERB. At least plain text syntax is better than incorrect language.