### PR TITLE
Support variable subscripts (eg, $v[subscript])

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -442,7 +442,12 @@
         'captures':
           '1':
             'name': 'punctuation.definition.variable.puppet'
-        'match': '(\\$)((::)?[a-z]\\w*)*((::)?[a-z_]\\w*)\\b'
+        # This regex looks for the following pattern:
+        #         $    (::segment)*      (::lastsegment)  ([array]|\b)
+        # segment names match [a-z_]\w*
+        # Both :: parts are optional, to match the following four cases:
+        #   $foo, $::foo, $foo::bar, $::foo::bar
+        'match': '(\\$)((::)?[a-z_]\\w*)*((::)?[a-z_]\\w*)((\\[\\w*\\])+|\\b)'
         'name': 'variable.other.readwrite.global.puppet'
       }
       {
@@ -451,7 +456,9 @@
             'name': 'punctuation.definition.variable.puppet'
           '2':
             'name': 'punctuation.definition.variable.puppet'
-        'match': '(\\$\\{)(?:[a-zA-Zx7f-xff\\$]|::)(?:[a-zA-Z0-9_x7f-xff\\$]|::)*(\\})'
+        # Comments as per above
+        #         ${       foo|::                  (foo|::)*                     ([array]?})
+        'match': '(\\$\\{)(?:[a-zA-Zx7f-xff\\$]|::)(?:[a-zA-Z0-9_x7f-xff\\$]|::)*((\\[\\w*\\])*\\})'
         'name': 'variable.other.readwrite.global.puppet'
       }
     ]

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -91,6 +91,109 @@ describe "Puppet grammar", ->
       expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
       expect(tokens[1]).toEqual value: '::foo', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
 
+      {tokens} = grammar.tokenizeLine('$foo::bar')
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo::bar', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+      {tokens} = grammar.tokenizeLine('$::foo::bar')
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo::bar', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+    it "tokenizes subscripted variables correctly", ->
+      {tokens} = grammar.tokenizeLine('$foo[bar]')
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo[bar]', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+      {tokens} = grammar.tokenizeLine('$::foo[bar]')
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo[bar]', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+      {tokens} = grammar.tokenizeLine('$foo::bar[baz]')
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo::bar[baz]', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+      {tokens} = grammar.tokenizeLine('$::foo::bar[baz]')
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo::bar[baz]', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+      {tokens} = grammar.tokenizeLine('$foo[bar][baz]')
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo[bar][baz]', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+      {tokens} = grammar.tokenizeLine('$::foo[bar][baz]')
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo[bar][baz]', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+      {tokens} = grammar.tokenizeLine('$foo::bar[baz][quux]')
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo::bar[baz][quux]', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+      {tokens} = grammar.tokenizeLine('$::foo::bar[baz][quux]')
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo::bar[baz][quux]', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+
+    it "tokenizes braced variables", ->
+      {tokens} = grammar.tokenizeLine('${foo}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+      {tokens} = grammar.tokenizeLine('${::foo}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+      {tokens} = grammar.tokenizeLine('${foo::bar}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo::bar', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+      {tokens} = grammar.tokenizeLine('${::foo::bar}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo::bar', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+    it "tokenizes braced subscripted variables", ->
+      {tokens} = grammar.tokenizeLine('${foo[bar]}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '[bar]}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+      {tokens} = grammar.tokenizeLine('${::foo[bar]}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '[bar]}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+      {tokens} = grammar.tokenizeLine('${foo::bar[baz]}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo::bar', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '[baz]}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+      {tokens} = grammar.tokenizeLine('${::foo::bar[baz]}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo::bar', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '[baz]}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+      {tokens} = grammar.tokenizeLine('${foo[bar][baz]}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '[bar][baz]}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+      {tokens} = grammar.tokenizeLine('${::foo[bar][baz]}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '[bar][baz]}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+      {tokens} = grammar.tokenizeLine('${foo::bar[baz][quux]}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: 'foo::bar', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '[baz][quux]}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
+      {tokens} = grammar.tokenizeLine('${::foo::bar[baz][quux]}')
+      expect(tokens[0]).toEqual value: '${', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+      expect(tokens[1]).toEqual value: '::foo::bar', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet']
+      expect(tokens[2]).toEqual value: '[baz][quux]}', scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']
+
     it "tokenizes resource types correctly", ->
       {tokens} = grammar.tokenizeLine("file {'/var/tmp':}")
       expect(tokens[0]).toEqual value: 'file', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'storage.type.puppet']


### PR DESCRIPTION
Want to open this pull request by stating I don't really understand what I did here 💁 

I'm pretty sure the syntax highlighting works, but I'm not sure how the grammar changes interact with variable completion. If it does there may be some issues -- please see the captured groups in the spec for more info.

Test text:

``` puppet

$var[test]
$::var[test]
$var::iable[test]
$::var::iable[test]

${var[test]}
${::var[test]}
${var::iable[test]}
${::var::iable[test]}

$var[te][st]
$::var[te][st]
$var::iable[te][st]
$::var::iable[te][st]

${var[te][st]}
${::var[te][st]}
${var::iable[te][st]}
${::var::iable[te][st]}
```

Old and busted:
<img width="229" alt="screen shot 2016-08-29 at 1 08 41 pm" src="https://cloud.githubusercontent.com/assets/379509/18039813/bdbbc2e8-6de9-11e6-8d4d-1340de9ec048.png">

New hotness:
<img width="234" alt="screen shot 2016-08-29 at 1 08 25 pm" src="https://cloud.githubusercontent.com/assets/379509/18039814/be6da8be-6de9-11e6-98c5-170513360ff9.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atom/language-puppet/44)
<!-- Reviewable:end -->
