### PR TITLE
Fix function calls inside parametrized classes

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -78,6 +78,11 @@
             'name': 'keyword.operator.assignment.puppet'
         'end': '(?=,|\\))'
         'name': 'meta.function.argument.default.untyped.puppet'
+        'patterns': [
+          {
+            'include': '#parameter-default-types'
+          }
+        ]
       }
       # Type `$param = ...,`
       {
@@ -361,14 +366,7 @@
         'include': '#array'
       }
       {
-        'begin': '([a-zA-Z_][a-zA-Z0-9_]*)(\\()'
-        'end': '(\\))'
-        'name': 'meta.function.puppet'
-        'patterns': [
-          {
-            'include': '#parameter-default-types'
-          }
-        ]
+        'include': '#function_call'
       }
       {
         'include': '#constants'
@@ -453,5 +451,18 @@
             'name': 'punctuation.definition.variable.puppet'
         'match': '(\\$\\{)(?:[a-zA-Zx7f-xff\\$]|::)(?:[a-zA-Z0-9_x7f-xff\\$]|::)*(\\})'
         'name': 'variable.other.readwrite.global.puppet'
+      }
+    ]
+  'function_call':
+    'begin': '([a-zA-Z_][a-zA-Z0-9_]*)(\\()'
+    'end': '\\)'
+    'name': 'meta.function-call.puppet'
+    'patterns': [
+      {
+        'include': '#parameter-default-types'
+      }
+      {
+        'match': ','
+        'name': 'punctuation.separator.parameters.puppet'
       }
     ]


### PR DESCRIPTION
Function call inside parametrized class definition breakes syntax.

This is used mainly when using hiera or lookup functions for default parameters.