### PR TITLE
add support for puppet heredoc

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -18,6 +18,23 @@
     'name': 'comment.block.puppet'
   }
   {
+    'begin': '@\\(([^:,^\\\,^\\(,^\\),^\\r,^\\n,^"]*)(/[\\$,t,s,r,n,u,L]*)?\\)$'
+    'end': '^(\\s*\\|)?(\\s*-\\s*)?\\s*(\\1)\\s*$'
+    'name': 'heredoc.block.puppet'
+  }
+  {
+    'begin': '@\\("([^:,^\\\,^\\(,^\\),^\\r,^\\n,^"]*)"(/[\\$,t,s,r,n,u,L]*)?\\)$'
+    'patterns':
+      [
+        {
+          'match': '(?<!\\\\)\\$(\\{?)[a-z,_][A-Z,a-z,0-9,_]*(\\}?)'
+          'name': 'variable.heredoc_interpolation.block.puppet'
+        }
+      ]
+    'end': '^(\\s*\\|)?(\\s*-\\s*)?\\s*(\\1)\\s*$'
+    'name': 'heredoc_interpolation.block.puppet'
+  }
+  {
     'begin': '^\\s*(node|class)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
     'captures':
       '1':


### PR DESCRIPTION
Heredoc support in atom/language-puppet does not currently existent.  This change adds basic support for puppet heredocs including highlighting for interpolated variables.  See [puppet heredoc documentation](https://puppet.com/docs/puppet/5.3/lang_data_string.html#heredocs).